### PR TITLE
Enhance Form.serialize to be able to handle deeply nested parameters.

### DIFF
--- a/src/prototype/lang/hash.js
+++ b/src/prototype/lang/hash.js
@@ -291,8 +291,27 @@ var Hash = Class.create(Enumerable, (function() {
   function toQueryPair(key, value) {
     if (Object.isUndefined(value)) return key;
     
-    value = String.interpret(value);
+    var result, resultArr;
 
+    // to deal with nested arrays (associative and otherwise) inside hash
+    if(typeof value == 'object') { 
+      resultArr = [];
+      for(key2 in value) {
+        if (typeof value[key2] != 'function') {
+          var fullKey = key + encodeURIComponent('[]['+key2+']');
+          var value2 = cleanQueryValue(value[key2]);
+          resultArr.push(fullKey+'='+value2);
+        }
+      }
+      result = resultArr.join('&');
+    } else {
+      result = key + '=' + cleanQueryValue(value);
+    }
+    return result;
+  }
+
+  function cleanQueryValue(value) {
+    value = String.interpret(value);
     // Normalize newlines as \r\n because the HTML spec says newlines should
     // be encoded as CRLFs.
     value = value.gsub(/(\r)?\n/, '\r\n');
@@ -300,7 +319,7 @@ var Hash = Class.create(Enumerable, (function() {
     // Likewise, according to the spec, spaces should be '+' rather than
     // '%20'.
     value = value.gsub(/%20/, '+');
-    return key + '=' + value;
+    return value;
   }
 
   /** related to: String#toQueryParams

--- a/test/formtests.html
+++ b/test/formtests.html
@@ -15,7 +15,7 @@
     <li><a href="layouttests.html">Layout Tests</a></li>
   </ul>
   <div id="mocha"></div>
-  <script src="../dist/prototype.min.js"></script>
+  <script src="../dist/prototype.js"></script>
   <script src="es5polyfill.js"></script>
   <script src="mocha.js"></script>
   <script src="proclaim.js"></script>
@@ -262,11 +262,13 @@
     <label>Bar collection 1</label>
     <input type="text" name="foo[bars][][name]" value="Bar 1" />
     <input type="text" name="foo[bars][][weight]" value="100 lbs" />
+    <input type="text" name="foo[bars][][tax]" value />
   </p>
   <p>
     <label>Bar collection 2</label>
     <input type="text" name="foo[bars][][name]" value="Bar 2" />
     <input type="text" name="foo[bars][][weight]" value="150 lbs" />
+    <input type="text" name="foo[bars][][tax]" value="1" />
   </p>
 </form>
 

--- a/test/unit/form.test.js
+++ b/test/unit/form.test.js
@@ -317,29 +317,37 @@ suite("Form Interactions",function(){
 
   test("Form.serialize() Multiple Select", function () {
     var form = $("form_with_multiple_select");
-    assert.equal("peewee=herman&colors=pink&colors=blue&colors=yellow&colors=not+grey&number=2", form.serialize(false));
+    assert.equal(
+      form.serialize(false),
+      "peewee=herman&colors=pink&colors=blue&colors=yellow&colors=not+grey&number=2"
+    );
     var hash = {
       peewee: 'herman',
       colors: ['pink', 'blue', 'yellow', 'not grey'],
       number: '2'
     };
-    assertHashEqual(hash, form.serialize(true));
-});
+    assert.equal(
+      JSON.stringify(form.serialize(true)),
+      JSON.stringify(hash)
+    );
+  });
 
   test("Form.serialize() With Nested Attributes", function() {
     var form = $("form_with_nested_attributes");
-    var expectedStr = "foo[name]=Foo+1&foo[combined_weight]=250+lbs&foo[bars][][name]=Bar+1&foo[bars][][weight]=100+lbs&foo[bars][][name]=Bar+2&foo[bars][][weight]=150+lbs";
+    var expectedStr = "foo[name]=Foo+1&foo[combined_weight]=250+lbs&foo[bars][][name]=Bar+1&foo[bars][][weight]=100+lbs&foo[bars][][tax]=&foo[bars][][name]=Bar+2&foo[bars][][weight]=150+lbs&foo[bars][][tax]=1";
     var decodedStr = decodeURIComponent(form.serialize(false));
     assert.equal(expectedStr, decodedStr);
     var expectedHash = {
       'foo[name]': 'Foo 1',
       'foo[combined_weight]': '250 lbs',
       'foo[bars]': [
-        {'name': 'Bar 1', 'weight': '100 lbs'},
-        {'name': 'Bar 2', 'weight': '150 lbs'}
+        {'name': 'Bar 1', 'weight': '100 lbs', 'tax': ''},
+        {'name': 'Bar 2', 'weight': '150 lbs', 'tax': '1'}
       ]
     }
-    assertHashEqual(expectedHash, form.serialize(true));
+    var actualHash = form.serialize(true);
+    assert.equal(typeof actualHash['foo[bars]'], 'object');
+    assert.equal(JSON.stringify(actualHash), JSON.stringify(expectedHash));
   });
   
   test("Form.request()", function(done) {


### PR DESCRIPTION
Turns out that assertHashEqual method used in the existing tests isn't
too smart. Wasn't picking up that hashes weren't equal after all.

Added better tests, then ensured that Form.serialize works as expected,
turning deeply nested params into proper objects.

Also modified toQueryPair to ensure that transforming those back to a
querystring to submit to server works as expected.
